### PR TITLE
fix: 🐛 Release branch for patch should not be main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,12 +61,14 @@ jobs:
       shell: bash
       run: |
         set -o xtrace
+        RELEASE_BRANCH="main"
         RELEASE_VERSION=${GITHUB_REF#refs/*/}
         major=$(echo "$RELEASE_VERSION"  | sed 's/^v\(.*\)/\1/' | cut -d. -f1)
         minor=$(echo "$RELEASE_VERSION" | cut -d. -f2)
         revision=$(echo "$RELEASE_VERSION" | cut -d. -f3)
         if [ "$revision" -gt 0 ];then
           revision=$(($revision-1))
+          RELEASE_BRANCH="release-${major}.${minor}"
         elif [ "$minor" -gt 0 ]; then
           minor=$(($minor-1))
         elif [ "$major" -gt 0 ]; then
@@ -88,6 +90,7 @@ jobs:
         echo "::set-output name=prev-release-version::$LAST_TAG"
         echo "::set-output name=repo-name::$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')"
         echo "::set-output name=repo-org::$(echo '${{ github.repository }}' | awk -F '/' '{print $1}')"
+        echo "::set-output name=release-branch::$RELEASE_BRANCH"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -110,7 +113,7 @@ jobs:
             --github-base-url https://github.com \
             --org ${{ steps.generate-release-details.outputs.repo-org }} \
             --repo ${{ steps.generate-release-details.outputs.repo-name }} \
-            --branch main \
+            --branch ${{ steps.generate-release-details.outputs.release-branch }} \
             --required-author "" \
             --start-sha ${{ steps.generate-release-details.outputs.start-sha }} \
             --end-sha ${{ steps.generate-release-details.outputs.end-sha }} \


### PR DESCRIPTION
The base branch from which a tag is cut for patch is not main but the
release-x.y branch. Hence for patch releases, the branch in release-note
generation should point to the release-x.y branch rather than the main
branch.

(cherry picked from commit f14cd5642c610aaa0437333c65a1243212c138d6)

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Release note generation should take into account the base branch from which the patch release is cut.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
